### PR TITLE
WIP: Mutability and document patching

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -40,3 +40,19 @@ def test_document_dumps():
         '    "hello": "world"\n'
         '}'
     )
+
+
+def test_document_patch():
+    doc = Document()
+
+    # Sets the root of the document since none
+    # yet exists.
+    doc.patch({
+        'hello': 'world'
+    })
+
+    doc = Document('[5]')
+    # Replace the entire matching array.
+    doc.patch([0, 1, 2], '.[]')
+    # Flatten and append to the array.
+    doc.patch([3, 4], '.[@]')

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -47,12 +47,17 @@ def test_document_patch():
 
     # Sets the root of the document since none
     # yet exists.
-    doc.patch({
-        'hello': 'world'
-    })
+    doc.patch({'hello': 'world'})
+    assert doc.dumps() == '{"hello":"world"}'
+    doc.patch([0, 1, 2])
+    assert doc.dumps() == '[0,1,2]'
+    doc.patch(1)
+    assert doc.dumps() == '1'
+    doc.patch(1.5)
+    assert doc.dumps() == '1.5'
 
-    doc = Document('[5]')
-    # Replace the entire matching array.
-    doc.patch([0, 1, 2], '.[]')
-    # Flatten and append to the array.
-    doc.patch([3, 4], '.[@]')
+    # doc = Document('[5]')
+    # # Replace the entire matching array.
+    # doc.patch([0, 1, 2], '.[]')
+    # # Flatten and append to the array.
+    # doc.patch([3, 4], '.[@]')


### PR DESCRIPTION
This supports using a `Document` as both an immutable document and a mutable document transparently. It will simply change the first time it is needed.

This is also the start of the `patch()` method, which allows you to patch a document by giving it an object and a JSON path pointing to where it should go.