### PR TITLE
add decimal.h to manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,4 @@ include yyjson/memory.c
 include yyjson/memory.h
 include yyjson/document.c
 include yyjson/document.h
+include yyjson/decimal.h


### PR DESCRIPTION
this prevents source installation of yyjson, which is probably a worthwhile step to confirm works in the release process.  4.0.4 has this issue and cannot be installed (by source)