### PR TITLE
Dictionary keys must be strings

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -166,6 +166,27 @@ def test_document_none_type():
     assert doc.as_obj == [None]
 
 
+def test_document_dict_type():
+    """
+    Ensure we can load and dump the dict type.
+    """
+    doc = Document('{"a": "b"}')
+    assert doc.dumps() == '{"a":"b"}'
+    assert doc.as_obj == {'a': 'b'}
+
+    doc = Document({"a": "b"})
+    assert doc.dumps() == '{"a":"b"}'
+    assert doc.as_obj == {'a': 'b'}
+
+    with pytest.raises(TypeError) as exc:
+        doc = Document({1: 'b'})
+    assert exc.value.args[0] == 'Dictionary keys must be strings'
+
+    with pytest.raises(TypeError) as exc:
+        doc = Document({'\ud83d\ude47': 'foo'})
+    assert exc.value.args[0] == 'Dictionary keys must be strings'
+
+
 def test_document_get_pointer():
     """
     Ensure JSON pointers work.

--- a/yyjson/document.c
+++ b/yyjson/document.c
@@ -364,6 +364,13 @@ static inline yyjson_mut_val *mut_primitive_to_element(
     while (PyDict_Next(obj, &i, &key, &value)) {
       Py_ssize_t str_len;
       const char *str = PyUnicode_AsUTF8AndSize(key, &str_len);
+      if (yyjson_unlikely(str == NULL)) {
+        PyErr_Format(PyExc_TypeError,
+            "Dictionary keys must be strings",
+            Py_TYPE(obj)->tp_name
+        );
+        return NULL;
+      }
       object_value = mut_primitive_to_element(self, doc, value);
       if (yyjson_unlikely(object_value == NULL)) {
         return NULL;


### PR DESCRIPTION
This PR fixes a bug (#12) where a `SystemError` would be raised when trying to serialize a dictionary with non-string keys. 

The following changes were made:
- Updated `mut_primitive_to_element()` to check the return value and handle the error case from `PyUnicode_AsUTF8AndSize()`.
- Added tests for new behavior.